### PR TITLE
[BE | 기업 상세] 공시 이슈 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	runtimeOnly 'com.h2database:h2'
-
 	// RDS (MySQL)
-	//implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	//runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// Neo4j
 	implementation 'org.springframework.boot:spring-boot-starter-data-neo4j'

--- a/src/main/java/com/example/noru/common/exception/CompanyException.java
+++ b/src/main/java/com/example/noru/common/exception/CompanyException.java
@@ -1,0 +1,17 @@
+package com.example.noru.common.exception;
+
+import com.example.noru.common.response.ResponseCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CompanyException extends RuntimeException{
+    private final ResponseCode responseCode;
+
+    public CompanyException(ResponseCode responseCode) {
+        super(responseCode.getMessage());
+        this.responseCode = responseCode;
+    }
+
+    public HttpStatus getHttpStatus() { return responseCode.getHttpStatus(); }
+}

--- a/src/main/java/com/example/noru/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/noru/common/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.example.noru.common.handler;
 
 
+import com.example.noru.common.exception.CompanyException;
 import com.example.noru.common.exception.NewsException;
 import com.example.noru.common.response.ApiResponse;
 import com.example.noru.common.response.ResponseCode;
@@ -24,6 +25,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NewsException.class)
     public ResponseEntity<ApiResponse<?>> handleNewsException(NewsException e) {
+
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(ApiResponse.error(e.getResponseCode()));
+    }
+
+    @ExceptionHandler(CompanyException.class)
+    public ResponseEntity<ApiResponse<?>> handleNewsException(CompanyException e) {
 
         return ResponseEntity
                 .status(e.getHttpStatus())

--- a/src/main/java/com/example/noru/common/response/ResponseCode.java
+++ b/src/main/java/com/example/noru/common/response/ResponseCode.java
@@ -15,9 +15,11 @@ public enum ResponseCode {
 
     SUCCESS_NEWS_LIST("SUCCESS_NEWS_LIST", "해당 날짜 뉴스 목록 조회에 성공하였습니다.", HttpStatus.OK),
     SUCCESS_NEWS_DETAIL("SUCCESS_NEWS_DETAIL", "뉴스 상세 조회에 성공하였습니다.", HttpStatus.OK),
+    SUCCESS_ANNOUNCEMENT("SUCCESS_ANNOUNCEMENT", "해당 기업 공시 이슈 조회에 성공하였습니다.", HttpStatus.OK),
 
 
     NEWS_NOT_FOUND("NEWS_NOT_FOUND", "뉴스 데이터가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    ANNOUNCEMENT_NOT_FOUND("ANNOUNCEMENT_NOT_FOUND", "해당 기업 공시 이슈가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 

--- a/src/main/java/com/example/noru/company/rds/controller/AnnouncementController.java
+++ b/src/main/java/com/example/noru/company/rds/controller/AnnouncementController.java
@@ -1,0 +1,30 @@
+package com.example.noru.company.rds.controller;
+
+import com.example.noru.common.response.ApiResponse;
+import com.example.noru.common.response.ResponseCode;
+import com.example.noru.company.rds.dto.AnnouncementDto;
+import com.example.noru.company.rds.entity.Announcement;
+import com.example.noru.company.rds.service.AnnouncementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/companies")
+@RequiredArgsConstructor
+public class AnnouncementController {
+
+    private final AnnouncementService announcementService;
+
+    @GetMapping("/{companyId}/announcement")
+    public ResponseEntity<?> getAnnouncements(@PathVariable String companyId) {
+        List<AnnouncementDto> result = announcementService.getAnnouncementsByCompany(companyId);
+
+        return ResponseEntity.ok(ApiResponse.success(ResponseCode.SUCCESS_ANNOUNCEMENT, result));
+    }
+}

--- a/src/main/java/com/example/noru/company/rds/dto/AnnouncementDto.java
+++ b/src/main/java/com/example/noru/company/rds/dto/AnnouncementDto.java
@@ -1,0 +1,23 @@
+package com.example.noru.company.rds.dto;
+
+import com.example.noru.company.rds.entity.Announcement;
+
+public record AnnouncementDto(
+        Long announcementId,
+        String companyId,
+        String category,
+        String title,
+        String announcementUrl,
+        String publishedAt
+) {
+    public static AnnouncementDto fromEntity(Announcement a) {
+        return new AnnouncementDto(
+                a.getId(),
+                a.getCompanyId(),
+                a.getCategory().name(),
+                a.getTitle(),
+                a.getAnnouncementUrl(),
+                a.getPublishedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/noru/company/rds/entity/Announcement.java
+++ b/src/main/java/com/example/noru/company/rds/entity/Announcement.java
@@ -1,0 +1,33 @@
+package com.example.noru.company.rds.entity;
+
+import com.example.noru.company.rds.type.Category;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "announcements")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Announcement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="announcement_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    private String title;
+
+    private String announcementUrl;
+
+    private String publishedAt;
+
+    private String companyId;
+
+}

--- a/src/main/java/com/example/noru/company/rds/entity/Company.java
+++ b/src/main/java/com/example/noru/company/rds/entity/Company.java
@@ -7,7 +7,7 @@ import jakarta.persistence.Table;
 import lombok.*;
 
 @Entity
-@Table(name = "Companies")
+@Table(name = "companies")
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/example/noru/company/rds/repository/AnnouncementRepository.java
+++ b/src/main/java/com/example/noru/company/rds/repository/AnnouncementRepository.java
@@ -1,0 +1,11 @@
+package com.example.noru.company.rds.repository;
+
+import com.example.noru.company.rds.entity.Announcement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
+
+    List<Announcement> findByCompanyIdOrderByPublishedAtDesc(String companyId);
+}

--- a/src/main/java/com/example/noru/company/rds/service/AnnouncementService.java
+++ b/src/main/java/com/example/noru/company/rds/service/AnnouncementService.java
@@ -1,0 +1,31 @@
+package com.example.noru.company.rds.service;
+
+import com.example.noru.common.exception.CompanyException;
+import com.example.noru.common.response.ResponseCode;
+import com.example.noru.company.rds.dto.AnnouncementDto;
+import com.example.noru.company.rds.repository.AnnouncementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AnnouncementService {
+    private final AnnouncementRepository announcementRepository;
+
+    public List<AnnouncementDto> getAnnouncementsByCompany(String companyId) {
+
+        List<AnnouncementDto> result = announcementRepository.findByCompanyIdOrderByPublishedAtDesc(companyId)
+                .stream()
+                .map(AnnouncementDto::fromEntity)
+                .toList();
+
+        if (result.isEmpty()) {
+            throw new CompanyException(ResponseCode.ANNOUNCEMENT_NOT_FOUND);
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/example/noru/company/rds/type/Category.java
+++ b/src/main/java/com/example/noru/company/rds/type/Category.java
@@ -1,0 +1,9 @@
+package com.example.noru.company.rds.type;
+
+public enum Category {
+    리스크,
+    투자,
+    지분,
+    실적,
+    기타
+}

--- a/src/main/java/com/example/noru/news/rds/entity/CompanySentiment.java
+++ b/src/main/java/com/example/noru/news/rds/entity/CompanySentiment.java
@@ -14,6 +14,7 @@ public class CompanySentiment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="sentiment_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/noru/news/rds/entity/News.java
+++ b/src/main/java/com/example/noru/news/rds/entity/News.java
@@ -16,6 +16,7 @@ public class News {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="news_id")
     private Long id;
 
     private String title;

--- a/src/main/java/com/example/noru/news/rds/entity/NewsImage.java
+++ b/src/main/java/com/example/noru/news/rds/entity/NewsImage.java
@@ -13,6 +13,7 @@ public class NewsImage {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="image_id")
     private Long id;
 
     private String imageUrl;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,17 @@ spring:
     name: noru
 
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:mysql://localhost:3307/stock_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
+        format_sql: true


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 기업 상세] 공시 이슈 조회 기능 구현

---

## 🔀 PR 개요
- 기업 상세 화면에 필요한 기업 공시(Announcement) 조회 기능을 추가

---

## ✅ 작업 내용
- Announcement 엔티티에서 company 연관관계 기반 조회 구조 적용
- AnnouncementRepository에 findByCompanyIdOrderByPublishedAtDesc() 메서드 추가
→ 회사별 공시를 최신순으로 조회
- 회사가 존재하지 않을 경우 CompanyNotFoundException 발생
- GlobalExceptionHandler에서 CompanyNotFoundException 공통 처리 로직 추가

---

## 📌 관련 이슈
- #6

---

## 📸 스크린샷 (선택)
<img width="865" height="663" alt="스크린샷 2025-12-12 오후 8 44 01" src="https://github.com/user-attachments/assets/3c383e35-93c2-4c8c-a375-ce1848e29144" />


---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
