### PR TITLE
Feat: S3 뉴스 데이터 수집 및 동기화 파이프라인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     // elasticsearch
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
+    // AWS SDK for java (S3)
+    implementation platform('software.amazon.awssdk:bom:2.21.1')
+    implementation 'software.amazon.awssdk:s3'
 
     // swagger
     compileOnly 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'

--- a/src/main/java/com/example/noru/common/config/S3Config.java
+++ b/src/main/java/com/example/noru/common/config/S3Config.java
@@ -1,0 +1,19 @@
+package com.example.noru.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/com/example/noru/common/sheduler/NewsPipelineScheduler.java
+++ b/src/main/java/com/example/noru/common/sheduler/NewsPipelineScheduler.java
@@ -1,0 +1,18 @@
+package com.example.noru.common.sheduler;
+
+import com.example.noru.news.rds.service.NewsSyncService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NewsPipelineScheduler {
+
+    private final NewsSyncService newsSyncService;
+
+    @Scheduled(fixedRate = 1000 * 60 * 10)
+    public void runPipeline() {
+        newsSyncService.syncNewsFromS3();
+    }
+}

--- a/src/main/java/com/example/noru/news/rds/dto/S3NewsDto.java
+++ b/src/main/java/com/example/noru/news/rds/dto/S3NewsDto.java
@@ -1,0 +1,34 @@
+package com.example.noru.news.rds.dto;
+
+import com.example.noru.news.rds.entity.News;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class S3NewsDto {
+    private String title;
+    private String content;
+    private String url;
+    private String publisher;
+    private String publishedAt;
+    private String companyCode; // 관련 종목 코드 (예: 005930)
+
+    // DTO -> Entity 변환 메서드
+    public News toEntity() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return News.builder()
+                .title(this.title)
+                .content(this.content)
+                .contentUrl(this.url)
+                .publisher(this.publisher)
+                .publishedAt(LocalDateTime.parse(this.publishedAt, formatter))
+                .companyId(this.companyCode)
+                .build();
+    }
+}

--- a/src/main/java/com/example/noru/news/rds/service/NewsSyncService.java
+++ b/src/main/java/com/example/noru/news/rds/service/NewsSyncService.java
@@ -1,0 +1,85 @@
+package com.example.noru.news.rds.service;
+
+import com.example.noru.news.rds.dto.S3NewsDto;
+import com.example.noru.news.rds.entity.News;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NewsSyncService {
+
+    private final S3Client s3Client;
+    private final NewsService newsService;
+    private final ObjectMapper objectMapper;
+
+    private static final String BUCKET_NAME = "noru-data";
+
+    public void syncNewsFromS3() {
+        log.info("S3 뉴스 동기화 시작...");
+
+        try {
+            ListObjectsV2Request listReq = ListObjectsV2Request.builder()
+                    .bucket(BUCKET_NAME)
+                    .build();
+
+            ListObjectsV2Response listRes = s3Client.listObjectsV2(listReq);
+
+            for (S3Object s3Object : listRes.contents()) {
+                String key = s3Object.key();
+
+                if (!key.endsWith(".json")) continue;
+
+                log.info("파일 처리 중: {}", key);
+                processFile(key);
+            }
+        } catch (Exception e) {
+            log.error("S3 동기화 중 오류 발생", e);
+        }
+    }
+
+    private void processFile(String key) {
+        try {
+            GetObjectRequest getReq = GetObjectRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .key(key)
+                    .build();
+
+            ResponseInputStream<GetObjectResponse> s3Object = s3Client.getObject(getReq);
+
+            List<S3NewsDto> dtoList = objectMapper.readValue(s3Object, new TypeReference<List<S3NewsDto>>() {
+            });
+
+            int count = 0;
+            for (S3NewsDto dto : dtoList) {
+                News news = dto.toEntity();
+                newsService.saveNews(news);
+                count++;
+            }
+            log.info("파일 '{}'에서 {}건의 뉴스 저장 완료", key, count);
+
+            deleteFile(key);
+        } catch (IOException e) {
+            log.error("파일 처리 실패: {}", key, e);
+        }
+    }
+
+    private void deleteFile(String key) {
+        DeleteObjectRequest deleteReq = DeleteObjectRequest.builder()
+                .bucket(BUCKET_NAME)
+                .key(key)
+                .build();
+        s3Client.deleteObject(deleteReq);
+        log.info("S3 파일 삭제 완료: {}", key);
+    }
+}


### PR DESCRIPTION
## ✅ PR 제목
- [기능 | 페이지명] 명확한 제목을 작성해주세요 (예: [기능 | 홈] 메뉴 투자 기능 구현)

---

## 🔀 PR 개요
- s3 관련 스케쥴러 작성

---

## ✅ 작업 내용
- AWS S3 SDK 의존성 추가 및 IAM Role 기반 S3 Client 설정
- 크롤링된 JSON 데이터 매핑을 위한 S3NewsDto 생성
- S3 파일 조회 -> 다운로드 -> DB 저장 -> 파일 삭제 로직 구현 (NewsSyncService)
- 기존 저장 로직 활용으로 Elasticsearch 자동 동기화 보장
- 1분 주기로 S3를 폴링(Polling)하는 스케줄러 등록
- 데이터 처리 후 중복 방지를 위한 S3 파일 삭제 로직 포함

---

## 📌 관련 이슈
- Close #이슈번호 (자동으로 연결되도록)

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
