### PR TITLE
Feat: Elasticsearch 기반 뉴스/기업 통합 검색 API 및 동기화 로직 구현

### DIFF
--- a/src/main/java/com/example/noru/company/document/CompanyDocument.java
+++ b/src/main/java/com/example/noru/company/document/CompanyDocument.java
@@ -1,0 +1,33 @@
+package com.example.noru.company.document;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(indexName = "company_index")
+public class CompanyDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Keyword)
+    private String stockCode;
+
+    @Field(type = FieldType.Text, analyzer = "nori")
+    private String name;
+
+    @Field(type = FieldType.Boolean)
+    private boolean isDomestic;
+
+    @Field(type = FieldType.Boolean)
+    private boolean isListed;
+}

--- a/src/main/java/com/example/noru/company/rds/repository/CompanySearchRepository.java
+++ b/src/main/java/com/example/noru/company/rds/repository/CompanySearchRepository.java
@@ -1,0 +1,16 @@
+package com.example.noru.company.rds.repository;
+
+import com.example.noru.company.document.CompanyDocument;
+import org.springframework.data.elasticsearch.annotations.Query;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CompanySearchRepository extends ElasticsearchRepository<CompanyDocument, Long> {
+
+    // 기업명(name)이나 종목코드(stockCode)에 키워드가 포함되면 검색
+    @Query("{\"multi_match\": {\"query\": \"?0\", \"fields\": [\"name\", \"stockCode\"]}}")
+    List<CompanyDocument> searchByNameOrCode(String keyword);
+}

--- a/src/main/java/com/example/noru/news/controller/NewsSearchController.java
+++ b/src/main/java/com/example/noru/news/controller/NewsSearchController.java
@@ -1,0 +1,58 @@
+package com.example.noru.news.controller;
+
+import com.example.noru.company.document.CompanyDocument;
+import com.example.noru.company.rds.repository.CompanySearchRepository;
+import com.example.noru.news.document.NewsDocument;
+import com.example.noru.news.rds.dto.SearchResponseDto;
+import com.example.noru.news.rds.service.NewsSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/news")
+@RequiredArgsConstructor
+@CrossOrigin(origins = "*")
+public class NewsSearchController {
+
+    private final NewsSearchService newsSearchService;
+    private final CompanySearchRepository companySearchRepository;
+
+    // 1. [통합 검색] 뉴스(제목+내용+기업명) + 기업(이름+코드) 동시에 검색
+    // 사용법: GET /api/news/total?keyword=삼성
+    @GetMapping("/total")
+    public ResponseEntity<SearchResponseDto> searchTotal(@RequestParam("keyword") String keyword) {
+
+        // 1-1. 뉴스 검색 (제목 + 본문 + 기업명)
+        List<NewsDocument> newsResult = newsSearchService.searchGlobal(keyword);
+
+        // 1-2. 기업 검색 (기업명 + 종목코드)
+        List<CompanyDocument> companyResult = companySearchRepository.searchByNameOrCode(keyword);
+
+        // 1-3. 결과 묶어서 반환
+        SearchResponseDto response = SearchResponseDto.builder()
+                .news(newsResult)
+                .companies(companyResult)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 2. [뉴스 검색] 뉴스만 검색하고 싶을 때
+    // 사용법: GET /api/news/search?keyword=반도체
+    @GetMapping("/search")
+    public ResponseEntity<List<NewsDocument>> searchNews(@RequestParam("keyword") String keyword) {
+        List<NewsDocument> result = newsSearchService.searchGlobal(keyword);
+        return ResponseEntity.ok(result);
+    }
+
+    // 3. [기업별 뉴스] 특정 종목코드의 뉴스만 보고 싶을 때
+    // 사용법: GET /api/news/company/005930
+    @GetMapping("/company/{code}")
+    public ResponseEntity<List<NewsDocument>> searchByCompany(@PathVariable("code") String code) {
+        List<NewsDocument> result = newsSearchService.searchByCompanyCode(code);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/example/noru/news/controller/NewsSyncController.java
+++ b/src/main/java/com/example/noru/news/controller/NewsSyncController.java
@@ -1,0 +1,28 @@
+package com.example.noru.news.controller;
+
+import com.example.noru.news.rds.service.NewsSyncService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/news/sync")
+@RequiredArgsConstructor
+public class NewsSyncController {
+
+    private final NewsSyncService newsSyncService;
+
+    @PostMapping("/full")
+    public ResponseEntity<String> fullSync() {
+        int count = newsSyncService.fullSyncToEs();
+        return ResponseEntity.ok("전체 동기화 완료! 총 " + count + "건 처리됨.");
+    }
+
+    @PostMapping("/companies/full")
+    public ResponseEntity<String> syncCompanies() {
+        int count = newsSyncService.fullSyncCompaniesToEs();
+        return ResponseEntity.ok("기업 동기화 완료: " + count + "건");
+    }
+}

--- a/src/main/java/com/example/noru/news/document/NewsDocument.java
+++ b/src/main/java/com/example/noru/news/document/NewsDocument.java
@@ -1,0 +1,45 @@
+package com.example.noru.news.document;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(indexName = "news_index")
+public class NewsDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Text, analyzer = "nori")
+    private String title;
+
+    @Field(type = FieldType.Text, analyzer = "nori")
+    private String content;
+
+    @Field(type = FieldType.Keyword) // 정확한 일치 검색용 (필터링)
+    private String publisher;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    private LocalDateTime publishedAt;
+
+    @Field(type = FieldType.Keyword) // 회사 코드로 필터링할 때 사용
+    private String companyCode;
+
+    @Field(type = FieldType.Text, analyzer = "nori")
+    private String companyName;
+
+    @Field(type = FieldType.Text)
+    private String url;
+}

--- a/src/main/java/com/example/noru/news/rds/dto/SearchResponseDto.java
+++ b/src/main/java/com/example/noru/news/rds/dto/SearchResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.noru.news.rds.dto;
+
+import com.example.noru.company.document.CompanyDocument;
+import com.example.noru.news.document.NewsDocument;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SearchResponseDto {
+    private List<NewsDocument> news;
+
+    private List<CompanyDocument> companies;
+}

--- a/src/main/java/com/example/noru/news/rds/repository/NewsSearchRepository.java
+++ b/src/main/java/com/example/noru/news/rds/repository/NewsSearchRepository.java
@@ -1,0 +1,21 @@
+package com.example.noru.news.rds.repository;
+
+import com.example.noru.news.document.NewsDocument;
+import org.springframework.data.elasticsearch.annotations.Query;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NewsSearchRepository extends ElasticsearchRepository<NewsDocument, Long> {
+
+    // 제목으로 검색하는 메서드 예시 (나중에 쓸 것)
+    List<NewsDocument> findByTitleContaining(String keyword);
+
+    // 회사 코드로 검색
+    List<NewsDocument> findByCompanyCode(String companyCode);
+
+    @Query("{\"multi_match\": {\"query\": \"?0\", \"fields\": [\"title\", \"content\", \"companyName\"]}}")
+    List<NewsDocument> searchByKeyword(String keyword);
+}

--- a/src/main/java/com/example/noru/news/rds/service/NewsSearchService.java
+++ b/src/main/java/com/example/noru/news/rds/service/NewsSearchService.java
@@ -1,0 +1,42 @@
+package com.example.noru.news.rds.service;
+
+import com.example.noru.news.document.NewsDocument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NewsSearchService {
+
+    private final com.example.noru.news.repository.NewsSearchRepository newsSearchRepository;
+
+    /**
+     * 1. 통합 검색 (Global Search)
+     * 제목(title), 본문(content), 기업명(companyName) 중 하나라도 키워드가 포함되면 반환합니다.
+     * * @param keyword 검색어 (예: "삼성", "반도체")
+     * @return 검색된 뉴스 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<NewsDocument> searchGlobal(String keyword) {
+        // Repository에 @Query로 정의해둔 multi_match 쿼리를 실행합니다.
+        return newsSearchRepository.searchByKeyword(keyword);
+    }
+
+    /**
+     * 2. 기업별 뉴스 조회
+     * 특정 종목코드(companyCode)를 가진 뉴스만 필터링해서 반환합니다.
+     * 사용자가 오른쪽 기업 리스트에서 특정 기업을 클릭했을 때 사용됩니다.
+     * * @param companyCode 종목코드 (예: "005930")
+     * @return 해당 기업의 뉴스 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<NewsDocument> searchByCompanyCode(String companyCode) {
+        // Spring Data Elasticsearch가 메서드 이름을 보고 자동으로 쿼리를 생성합니다.
+        return newsSearchRepository.findByCompanyCode(companyCode);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         jdbc:
@@ -24,7 +24,7 @@ spring:
         format_sql: true
 
   elasticsearch:
-    uris: http://10.0.3.45:9200
+    uris: http://localhost:9200
 
 app:
   korea-invest:


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 검색] ElasticSearch 기반 뉴스/기업 통합 검색 기능 개발

---

## 🔀 PR 개요
- ElasticSearch 기반 뉴스/기업 통합 검색 API 및 동기화 로직 구현

---

## ✅ 작업 내용
[검색 엔진 도입 및 인프라]
- Docker Compose에 Elasticsearch(7.17.10) 및 Kibana 컨테이너 추가
- 로컬/서버 아키텍처 호환성을 위해 Kibana 이미지 버전 고정

[데이터 모델링]
- NewsDocument: 뉴스 데이터 인덱싱 매핑 (제목, 본문, 기업명)
- CompanyDocument: 기업 데이터 인덱싱 매핑 (이름, 종목코드)
- Repository: 제목+본문+기업명 통합 검색을 위한 multi_match 쿼리 구현

[비즈니스 로직]
- NewsSyncService: MySQL 데이터를 ES로 적재하는 전체 동기화(Full Sync) 로직 구현
  - 뉴스 적재 시 기업 ID를 이용해 기업명(CompanyName) 매핑 로직 추가
- NewsSearchService: 키워드 기반 통합 검색 및 기업별 뉴스 필터링 기능 구현

[API 구현]
- GET /api/news/total: 뉴스 및 기업 동시 검색 (통합 검색)
- GET /api/news/search: 뉴스 단독 검색
- GET /api/news/company/{code}: 특정 기업 뉴스 조회
- POST /api/news/sync/full: 데이터 강제 동기화 트리거
- SearchResponseDto: 통합 검색 응답 규격 정의


---

## 📌 관련 이슈
- Close #24 

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
