### PR TITLE
[BE | 기업상세] 기업 상세 그래프 양방향 조회 가능 

### DIFF
--- a/src/main/java/com/example/noru/common/response/ResponseCode.java
+++ b/src/main/java/com/example/noru/common/response/ResponseCode.java
@@ -17,6 +17,7 @@ public enum ResponseCode {
     SUCCESS_NEWS_COMPANY("SUCCESS_NEWS_COMPANY", "특정 기업 뉴스 목록 조회에 성공하였습니다.", HttpStatus.OK),
     SUCCESS_NEWS_DETAIL("SUCCESS_NEWS_DETAIL", "뉴스 상세 조회에 성공하였습니다.", HttpStatus.OK),
     SUCCESS_ANNOUNCEMENT("SUCCESS_ANNOUNCEMENT", "해당 기업 공시 이슈 조회에 성공하였습니다.", HttpStatus.OK),
+    SUCCESS_COMPANY_DETAIL("SUCCESS_COMPANY_DETAIL", "기업 상세 조회에 조회에 성공하였습니다.", HttpStatus.OK),
 
 
     NEWS_NOT_FOUND("NEWS_NOT_FOUND", "뉴스 데이터가 존재하지 않습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/example/noru/common/response/ResponseCode.java
+++ b/src/main/java/com/example/noru/common/response/ResponseCode.java
@@ -22,6 +22,7 @@ public enum ResponseCode {
 
     NEWS_NOT_FOUND("NEWS_NOT_FOUND", "뉴스 데이터가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     ANNOUNCEMENT_NOT_FOUND("ANNOUNCEMENT_NOT_FOUND", "해당 기업 공시 이슈가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    COMPANY_RELATION_NOT_FOUND("COMPANY_RELATION_NOT_FOUND", "연관 관계 기업이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 

--- a/src/main/java/com/example/noru/company/controller/CompanyController.java
+++ b/src/main/java/com/example/noru/company/controller/CompanyController.java
@@ -43,8 +43,8 @@ public class CompanyController {
     }
 
     @GetMapping("/{ticker}")
-    public CompanyGraphResponseDto getGraph(@PathVariable String ticker) {
+    public ResponseEntity<ApiResponse<CompanyGraphResponseDto>> getGraph(@PathVariable String ticker) {
         log.info("Request ticker = {}", ticker);
-        return graphService.getCompanyGraph(ticker);
+        return ResponseEntity.ok(ApiResponse.success(ResponseCode.SUCCESS_COMPANY_DETAIL, graphService.getCompanyGraph(ticker)));
     }
 }

--- a/src/main/java/com/example/noru/company/controller/CompanyController.java
+++ b/src/main/java/com/example/noru/company/controller/CompanyController.java
@@ -2,6 +2,7 @@ package com.example.noru.company.controller;
 
 import com.example.noru.common.response.ApiResponse;
 import com.example.noru.common.response.ResponseCode;
+import com.example.noru.company.graph.dto.CompanyGraphResponseDto;
 import com.example.noru.company.graph.node.CompanyGraphEntity;
 import com.example.noru.company.graph.service.CompanyGraphService;
 import com.example.noru.company.rds.dto.AnnouncementDto;
@@ -41,9 +42,9 @@ public class CompanyController {
         return ResponseEntity.ok(ApiResponse.success(ResponseCode.SUCCESS_NEWS_COMPANY, newsService.getNewsByCompanyId(companyId)));
     }
 
-    @GetMapping("/{corpCode}")
-    public CompanyGraphEntity getGraph(@PathVariable String corpCode) {
-        log.info("Request corpCode = {}", corpCode);
-        return graphService.getCompanyGraph(corpCode);
+    @GetMapping("/{ticker}")
+    public CompanyGraphResponseDto getGraph(@PathVariable String ticker) {
+        log.info("Request ticker = {}", ticker);
+        return graphService.getCompanyGraph(ticker);
     }
 }

--- a/src/main/java/com/example/noru/company/graph/dto/CompanyGraphResponseDto.java
+++ b/src/main/java/com/example/noru/company/graph/dto/CompanyGraphResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.noru.company.graph.dto;
+
+import java.util.List;
+
+public record CompanyGraphResponseDto(
+        String companyId,
+        String name,
+        boolean isListed,
+        List<RelatedCompanyDto> related
+) {}

--- a/src/main/java/com/example/noru/company/graph/dto/RelatedCompanyBuilder.java
+++ b/src/main/java/com/example/noru/company/graph/dto/RelatedCompanyBuilder.java
@@ -1,0 +1,39 @@
+package com.example.noru.company.graph.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RelatedCompanyBuilder {
+
+    private final String companyId;
+    private final String name;
+    private final boolean isDomestic;
+    private final boolean isListed;
+    private final List<TagDto> tags = new ArrayList<>();
+
+    public RelatedCompanyBuilder(
+            String companyId,
+            String name,
+            boolean isDomestic,
+            boolean isListed
+    ) {
+        this.companyId = companyId;
+        this.name = name;
+        this.isDomestic = isDomestic;
+        this.isListed = isListed;
+    }
+
+    public void addTag(TagDto tag) {
+        tags.add(tag);
+    }
+
+    public RelatedCompanyDto build() {
+        return new RelatedCompanyDto(
+                companyId,
+                name,
+                isDomestic,
+                isListed,
+                tags
+        );
+    }
+}

--- a/src/main/java/com/example/noru/company/graph/dto/RelatedCompanyDto.java
+++ b/src/main/java/com/example/noru/company/graph/dto/RelatedCompanyDto.java
@@ -1,0 +1,11 @@
+package com.example.noru.company.graph.dto;
+
+import java.util.List;
+
+public record RelatedCompanyDto(
+        String companyId,
+        String name,
+        boolean isDomestic,
+        boolean isListed,
+        List<TagDto> tags
+) {}

--- a/src/main/java/com/example/noru/company/graph/dto/TagDto.java
+++ b/src/main/java/com/example/noru/company/graph/dto/TagDto.java
@@ -1,0 +1,8 @@
+package com.example.noru.company.graph.dto;
+
+public record TagDto(
+        String label,
+        Long newsId,
+        String relReason
+) {}
+

--- a/src/main/java/com/example/noru/company/graph/dto/TagDto.java
+++ b/src/main/java/com/example/noru/company/graph/dto/TagDto.java
@@ -2,7 +2,9 @@ package com.example.noru.company.graph.dto;
 
 public record TagDto(
         String label,
+        String direction,
         Long newsId,
         String relReason
 ) {}
+
 

--- a/src/main/java/com/example/noru/company/graph/node/CompanyGraphEntity.java
+++ b/src/main/java/com/example/noru/company/graph/node/CompanyGraphEntity.java
@@ -15,10 +15,12 @@ import java.util.List;
 public class CompanyGraphEntity {
 
     @Id
-    private String ticker;
+    private String id;                 // "corp:01480708"
 
     @Property("corp_code")
     private String corpCode;
+
+    private String ticker;
 
     private String name;
 
@@ -31,9 +33,7 @@ public class CompanyGraphEntity {
     private boolean isListed;
 
 
-    @Relationship(type = "RELATION", direction = Relationship.Direction.OUTGOING)
-    private List<CompanyGraphRelation> outgoing;
-
     @Relationship(type = "RELATION", direction = Relationship.Direction.INCOMING)
-    private List<CompanyGraphRelation> incoming;
+    private List<CompanyGraphRelation> relations;
+
 }

--- a/src/main/java/com/example/noru/company/graph/node/CompanyGraphEntity.java
+++ b/src/main/java/com/example/noru/company/graph/node/CompanyGraphEntity.java
@@ -33,7 +33,10 @@ public class CompanyGraphEntity {
     private boolean isListed;
 
 
-    @Relationship(type = "RELATION")
-    private List<CompanyGraphRelation> relations;
+    @Relationship(type = "RELATION", direction = Relationship.Direction.OUTGOING)
+    private List<CompanyGraphRelation> outgoingRelations;
+
+    @Relationship(type = "RELATION", direction = Relationship.Direction.INCOMING)
+    private List<CompanyGraphRelation> incomingRelations;
 
 }

--- a/src/main/java/com/example/noru/company/graph/node/CompanyGraphEntity.java
+++ b/src/main/java/com/example/noru/company/graph/node/CompanyGraphEntity.java
@@ -15,27 +15,25 @@ import java.util.List;
 public class CompanyGraphEntity {
 
     @Id
-    private String id;                 // "corp:01480708"
+    private String ticker;
 
     @Property("corp_code")
     private String corpCode;
 
-    private String ticker;
-
     private String name;
-
-    private String market;
-
-    @Property("market_cap_eok")
-    private Double marketCapEok;
-
-    @Property("cap_bucket")
-    private String capBucket;
 
     @Property("entity_type")
     private String entityType;
 
-    @Relationship(type = "RELATION", direction = Relationship.Direction.INCOMING)
-    private List<CompanyGraphRelation> relations;
+    private String country;
 
+    @Property("is_listed")
+    private boolean isListed;
+
+
+    @Relationship(type = "RELATION", direction = Relationship.Direction.OUTGOING)
+    private List<CompanyGraphRelation> outgoing;
+
+    @Relationship(type = "RELATION", direction = Relationship.Direction.INCOMING)
+    private List<CompanyGraphRelation> incoming;
 }

--- a/src/main/java/com/example/noru/company/graph/node/CompanyGraphEntity.java
+++ b/src/main/java/com/example/noru/company/graph/node/CompanyGraphEntity.java
@@ -33,7 +33,7 @@ public class CompanyGraphEntity {
     private boolean isListed;
 
 
-    @Relationship(type = "RELATION", direction = Relationship.Direction.INCOMING)
+    @Relationship(type = "RELATION")
     private List<CompanyGraphRelation> relations;
 
 }

--- a/src/main/java/com/example/noru/company/graph/relationship/CompanyGraphRelation.java
+++ b/src/main/java/com/example/noru/company/graph/relationship/CompanyGraphRelation.java
@@ -15,28 +15,17 @@ public class CompanyGraphRelation {
     @GeneratedValue
     private Long internalId;
 
-    @Property("event_date")
-    private String eventDate;
-
-    @Property("event_tag")
-    private String eventTag;
-
-    @Property("event_type")
-    private String eventType;
-
-    @Property("rcept_no")
-    private String rceptNo;
-
     @Property("rel_type")
     private String relType;
-
-    @Property("source_json")
-    private String sourceJson;
 
     @Property("extra_json")
     private String extraJson;
 
-    private String weight;
+    @Property("news_id")
+    private String newsId;
+
+    @Property("rel_reason")
+    private String relReason;
 
     @TargetNode
     private CompanyGraphEntity investor;

--- a/src/main/java/com/example/noru/company/graph/repository/CompanyGraphRepository.java
+++ b/src/main/java/com/example/noru/company/graph/repository/CompanyGraphRepository.java
@@ -10,10 +10,14 @@ public interface CompanyGraphRepository
         extends Neo4jRepository<CompanyGraphEntity, String> {
 
     @Query("""
-    MATCH (e:Entity {corp_code: $id})
-    OPTIONAL MATCH (e)<-[r:RELATION]-(t:Entity)
-    RETURN e, collect(r) AS relations, collect(t) AS targets
+    MATCH (e:Entity {ticker: $ticker})
+    OPTIONAL MATCH (e)-[r:RELATION]->(t:Entity)
+    OPTIONAL MATCH (e)<-[r2:RELATION]-(t2:Entity)
+    RETURN e,
+           collect(r), collect(t),
+           collect(r2), collect(t2)
     """)
-    Optional<CompanyGraphEntity> findEntityWithRelations(String id);
+    Optional<CompanyGraphEntity> findByTicker(String ticker);
+
 
 }

--- a/src/main/java/com/example/noru/company/graph/repository/CompanyGraphRepository.java
+++ b/src/main/java/com/example/noru/company/graph/repository/CompanyGraphRepository.java
@@ -11,7 +11,7 @@ public interface CompanyGraphRepository
 
     @Query("""
     MATCH (e:Entity {ticker: $id})
-    OPTIONAL MATCH (e)<-[r:RELATION]-(t:Entity)
+    OPTIONAL MATCH (e)-[r:RELATION]-(t:Entity)
     RETURN e, collect(r) AS relations, collect(t) AS targets
     """)
     Optional<CompanyGraphEntity> findByTicker(String id);

--- a/src/main/java/com/example/noru/company/graph/repository/CompanyGraphRepository.java
+++ b/src/main/java/com/example/noru/company/graph/repository/CompanyGraphRepository.java
@@ -10,14 +10,10 @@ public interface CompanyGraphRepository
         extends Neo4jRepository<CompanyGraphEntity, String> {
 
     @Query("""
-    MATCH (e:Entity {ticker: $ticker})
-    OPTIONAL MATCH (e)-[r:RELATION]->(t:Entity)
-    OPTIONAL MATCH (e)<-[r2:RELATION]-(t2:Entity)
-    RETURN e,
-           collect(r), collect(t),
-           collect(r2), collect(t2)
+    MATCH (e:Entity {ticker: $id})
+    OPTIONAL MATCH (e)<-[r:RELATION]-(t:Entity)
+    RETURN e, collect(r) AS relations, collect(t) AS targets
     """)
-    Optional<CompanyGraphEntity> findByTicker(String ticker);
-
+    Optional<CompanyGraphEntity> findByTicker(String id);
 
 }

--- a/src/main/java/com/example/noru/company/graph/service/CompanyGraphService.java
+++ b/src/main/java/com/example/noru/company/graph/service/CompanyGraphService.java
@@ -1,20 +1,97 @@
 package com.example.noru.company.graph.service;
 
+import com.example.noru.company.graph.dto.CompanyGraphResponseDto;
+import com.example.noru.company.graph.dto.RelatedCompanyBuilder;
+import com.example.noru.company.graph.dto.TagDto;
 import com.example.noru.company.graph.node.CompanyGraphEntity;
+import com.example.noru.company.graph.relationship.CompanyGraphRelation;
 import com.example.noru.company.graph.repository.CompanyGraphRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 @Service
 @RequiredArgsConstructor
 public class CompanyGraphService {
 
-    private final CompanyGraphRepository repository;
+    private final CompanyGraphRepository companyGraphRepository;
 
-    @Transactional("neo4jTransactionManager")
-    public CompanyGraphEntity getCompanyGraph(String entityId) {
-        return repository.findEntityWithRelations(entityId)
-                .orElseThrow(() -> new IllegalArgumentException("Entity not found"));
+    public CompanyGraphResponseDto getCompanyGraph(String ticker) {
+
+        CompanyGraphEntity root = companyGraphRepository
+                .findByTicker(ticker)
+                .orElseThrow(() -> new RuntimeException("기업 없음"));
+
+        Map<String, RelatedCompanyBuilder> relatedMap = new LinkedHashMap<>();
+
+        // 🔥 OUT + IN 합침
+        List<CompanyGraphRelation> relations =
+                Stream.concat(
+                        root.getOutgoing().stream(),
+                        root.getIncoming().stream()
+                ).toList();
+
+        for (CompanyGraphRelation relation : relations) {
+
+            CompanyGraphEntity target = relation.getInvestor();
+
+            String companyKey = resolveCompanyKey(target);
+
+            relatedMap.computeIfAbsent(companyKey, key -> {
+
+                boolean isListed =
+                        target.getTicker() != null && !target.getTicker().isBlank();
+
+                boolean isDomestic =
+                        target.getCountry() == null
+                                || "Korea".equalsIgnoreCase(target.getCountry());
+
+                return new RelatedCompanyBuilder(
+                        companyKey,
+                        target.getName(),
+                        isDomestic,
+                        isListed
+                );
+            });
+
+            relatedMap.get(companyKey).addTag(
+                    new TagDto(
+                            relation.getRelType(),
+                            relation.getNewsId() != null
+                                    ? Long.parseLong(relation.getNewsId())
+                                    : null,
+                            relation.getRelReason()
+                    )
+            );
+        }
+
+        return new CompanyGraphResponseDto(
+                root.getTicker(),
+                root.getName(),
+                root.isListed(),
+                relatedMap.values()
+                        .stream()
+                        .map(RelatedCompanyBuilder::build)
+                        .toList()
+        );
+    }
+
+    /**
+     * ✅ 핵심: Map key는 절대 겹치면 안 된다
+     */
+    private String resolveCompanyKey(CompanyGraphEntity entity) {
+
+        if (entity.getTicker() != null && !entity.getTicker().isBlank()) {
+            return entity.getTicker();          // 1️⃣ 상장사
+        }
+
+        if (entity.getCorpCode() != null && !entity.getCorpCode().isBlank()) {
+            return entity.getCorpCode();        // 2️⃣ 비상장
+        }
+
+        return "neo4j:" + entity.getTicker();       // 3️⃣ 최후 방어선 (절대 유니크)
     }
 }


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 기업상세] 기업 상세 그래프 양방향 조회 가능 

---

## 🔀 PR 개요
- Neo4j 그래프 DB를 활용해 기업 상세 페이지에서 기업 간 연관 관계를 양방향으로 조회하고, 관계 방향에 따른 의미를 구분해 반환하도록 구현했습니다.

---

## ✅ 작업 내용
- Neo4j Entity 노드 및 RELATION 관계 매핑 엔티티 정의
- @RelationshipProperties 기반 관계 속성(relType, newsId, relReason, extraJson) 모델링
- 기업 티커 기준 그래프 단건 조회 Repository 구현
- 관계 방향을 기준으로 INCOMING / OUTGOING 관계 분리 매핑
- 서비스 레이어에서 양방향 관계(IN + OUT) 통합 처리 로직 구현
- 관계 방향에 따라 태그 의미를 구분하여 응답 (IN / OUT)
- extra_json에 포함된 상세 사유(reason)를 파싱하여 관계 설명(relReason)에 반영
- 동일 기업에 대한 다중 관계를 태그 형태로 그룹핑 처리
---

## 📌 관련 이슈
- #16

---

## 📸 스크린샷 (선택)
<img width="716" height="649" alt="스크린샷 2025-12-14 오전 11 47 08" src="https://github.com/user-attachments/assets/e9a96cb5-dd6f-40b8-9fc2-9c3238b893aa" />



---

## ⚠️ 기타 사항
- 추후 최대 주주 여부 필드 추가 예정
