### PR TITLE
[BE | 현재가] 가격 정보 확장

### DIFF
--- a/src/main/java/com/example/noru/news/rds/dto/response/CompanySentimentDto.java
+++ b/src/main/java/com/example/noru/news/rds/dto/response/CompanySentimentDto.java
@@ -1,10 +1,12 @@
 package com.example.noru.news.rds.dto.response;
 
 public record CompanySentimentDto(
-        String companyId,
-        String name,
+        String stockCode,
+        String companyName,
         boolean isDomestic,
         boolean isListed,
         String sentiment,
-        long price
+        long price,
+        long diffPrice,
+        double diffRate
 ) {}

--- a/src/main/java/com/example/noru/news/rds/service/NewsService.java
+++ b/src/main/java/com/example/noru/news/rds/service/NewsService.java
@@ -13,6 +13,7 @@ import com.example.noru.news.rds.entity.OutboxEvent; // Outbox 엔티티 import
 import com.example.noru.news.rds.repository.NewsRepository;
 import com.example.noru.news.rds.repository.OutboxEventRepository; // Outbox 리포지토리 import
 import com.example.noru.price.config.PriceParsingConfig;
+import com.example.noru.price.dto.PriceDto;
 import com.example.noru.price.service.PriceRedisService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -136,17 +137,21 @@ public class NewsService {
                                         false,
                                         false,
                                         cs.getSentiment(),
+                                        -1,
+                                        0,
                                         0
+
                                 );
                             }
 
                             Company company = companyOpt.get();
                             String stockCode = company.getStockCode();
 
+                            PriceDto priceDto = new PriceDto(stockCode, -1, 0, 0.0);
+
                             String json = priceRedisService.get(stockCode);
-                            long price = 0;
                             if (json != null) {
-                                price = PriceParsingConfig.parsePrice(stockCode, json).price();
+                                priceDto = PriceParsingConfig.parsePrice(stockCode, json);
                             }
 
                             return new CompanySentimentDto(
@@ -155,8 +160,11 @@ public class NewsService {
                                     company.isDomestic(),
                                     company.isListed(),
                                     cs.getSentiment(),
-                                    price
+                                    priceDto.price(),
+                                    priceDto.diffPrice(),
+                                    priceDto.diffRate()
                             );
+
                         })
                         .filter(dto -> dto != null)
                         .toList();

--- a/src/main/java/com/example/noru/price/config/PriceParsingConfig.java
+++ b/src/main/java/com/example/noru/price/config/PriceParsingConfig.java
@@ -8,20 +8,32 @@ public class PriceParsingConfig {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    public static PriceDto parsePrice(String code, String json) {
+    public static PriceDto parsePrice(String stockCode, String json) {
         try {
             JsonNode root = mapper.readTree(json);
             JsonNode output = root.get("output");
 
-            if (output == null || output.get("stck_prpr") == null) {
-                return new PriceDto(code, -1);
+            if (output == null) {
+                return empty(stockCode);
             }
 
-            long price = output.get("stck_prpr").asLong();
-            return new PriceDto(code, price);
+            long price = output.path("stck_prpr").asLong(-1);
+            long diffPrice = output.path("prdy_vrss").asLong(0);
+            double diffRate = output.path("prdy_ctrt").asDouble(0.0);
+
+            return new PriceDto(
+                    stockCode,
+                    price,
+                    diffPrice,
+                    diffRate
+            );
 
         } catch (Exception e) {
-            return new PriceDto(code, -1); // 오류 시 -1
+            return empty(stockCode);
         }
+    }
+
+    private static PriceDto empty(String stockCode) {
+        return new PriceDto(stockCode, -1, 0, 0.0);
     }
 }

--- a/src/main/java/com/example/noru/price/dto/PriceDto.java
+++ b/src/main/java/com/example/noru/price/dto/PriceDto.java
@@ -2,5 +2,7 @@ package com.example.noru.price.dto;
 
 public record PriceDto(
         String code,
-        long price
+        long price,          // stck_prpr
+        long diffPrice,      // prdy_vrss
+        double diffRate // prdy_ctrt
 ) {}


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 현재가] 가격 정보 확장

---

## 🔀 PR 개요
- 기업 감정 정보에 현재가·등락가·등락률 정보를 함께 제공하도록 개선했습니다.

---

## ✅ 작업 내용
- redis 가격 JSON에서 다음 필드 파싱 추가
- 현재가(stck_prpr)
- 전일 대비 등락가(prdy_vrss)
- 전일 대비 등락률(prdy_ctrt)
- PriceDto 확장 및 CompanySentimentDto에 가격 정보 포함

---

## 📌 관련 이슈
- #28

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
