### PR TITLE
Feat: 뉴스 데이터 정합성을 위한 Outbox Pattern 및 스케줄러 구현

### DIFF
--- a/src/main/java/com/example/noru/admin/controller/AdminController.java
+++ b/src/main/java/com/example/noru/admin/controller/AdminController.java
@@ -1,0 +1,57 @@
+package com.example.noru.admin.controller;
+
+import com.example.noru.news.rds.dto.NewsEsDto;
+import com.example.noru.news.rds.entity.News;
+import com.example.noru.news.rds.entity.OutboxEvent;
+import com.example.noru.news.rds.repository.NewsRepository;
+import com.example.noru.news.rds.repository.OutboxEventRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+@Slf4j
+public class AdminController {
+
+    private final NewsRepository newsRepository;
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
+
+    @PostMapping("/backfill/outbox")
+    public String backfillOutbox() {
+        List<News> allNews = newsRepository.findAll();
+        int count = 0;
+
+        for (News news : allNews) {
+            try {
+                // DTO 변환
+                NewsEsDto dto = NewsEsDto.from(news);
+                String payload = objectMapper.writeValueAsString(dto);
+
+                // Outbox 이벤트 강제 생성
+                OutboxEvent event = OutboxEvent.builder()
+                        .aggregateType("NEWS")
+                        .aggregateId(news.getId())
+                        .eventType("BACKFILL")
+                        .payload(payload)
+                        .status("PENDING") // PENDING으로 넣어야 스케줄러가 가져감
+                        .createdAt(LocalDateTime.now())
+                        .build();
+
+                outboxEventRepository.save(event);
+                count++;
+            } catch (Exception e) {
+                log.error("Failed backfill for news id: {}", news.getId(), e);
+            }
+        }
+        return count + "건의 뉴스에 대해 Outbox 이벤트를 생성했습니다.";
+    }
+}

--- a/src/main/java/com/example/noru/news/rds/dto/NewsEsDto.java
+++ b/src/main/java/com/example/noru/news/rds/dto/NewsEsDto.java
@@ -4,6 +4,8 @@ import com.example.noru.news.rds.entity.News;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 public class NewsEsDto {
@@ -11,8 +13,14 @@ public class NewsEsDto {
     private String title;
     private String description;
     private String content;
-    private String publishedAt;
+
+    // String 대신 LocalDateTime 사용 추천 (시간 정보 유지)
+    private LocalDateTime publishedAt;
+
     private String publisher;
+
+    // [중요] 기업 매핑을 위해 반드시 필요!
+    private String companyId;
 
     // News 엔티티를 받아서 DTO로 변환하는 정적 메서드
     public static NewsEsDto from(News news) {
@@ -21,10 +29,9 @@ public class NewsEsDto {
                 .title(news.getTitle())
                 .description(news.getDescription())
                 .content(news.getContent())
-                .publishedAt(news.getPublishedAt()
-                        .toLocalDate()
-                        .toString())
+                .publishedAt(news.getPublishedAt()) // 시간 정보까지 그대로 전달
                 .publisher(news.getPublisher())
+                .companyId(news.getCompanyId())     // 필드 매핑 추가
                 .build();
     }
 }

--- a/src/main/java/com/example/noru/news/rds/service/NewsSearchService.java
+++ b/src/main/java/com/example/noru/news/rds/service/NewsSearchService.java
@@ -1,11 +1,16 @@
 package com.example.noru.news.rds.service;
 
+import com.example.noru.company.rds.entity.Company;
+import com.example.noru.company.rds.repository.CompanyRepository;
 import com.example.noru.news.document.NewsDocument;
+import com.example.noru.news.rds.dto.NewsEsDto;
+import com.example.noru.news.rds.entity.News;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -14,6 +19,7 @@ import java.util.List;
 public class NewsSearchService {
 
     private final com.example.noru.news.repository.NewsSearchRepository newsSearchRepository;
+    private final CompanyRepository companyRepository;
 
     /**
      * 1. 통합 검색 (Global Search)
@@ -38,5 +44,36 @@ public class NewsSearchService {
     public List<NewsDocument> searchByCompanyCode(String companyCode) {
         // Spring Data Elasticsearch가 메서드 이름을 보고 자동으로 쿼리를 생성합니다.
         return newsSearchRepository.findByCompanyCode(companyCode);
+    }
+
+    /**
+     * [추가] Outbox 스케줄러가 호출하는 메서드
+     * News 엔티티를 받아서 ES용 NewsDocument로 변환 후 저장
+     */
+    @Transactional
+    public void saveToElasticsearch(NewsEsDto dto) {
+        // 1. 기업명 조회 (오류 났던 부분 수정: parseLong 제거)
+        String companyName = "기타";
+
+        if (dto.getCompanyId() != null) {
+            // String ID를 그대로 넘깁니다.
+            companyName = companyRepository.findById(dto.getCompanyId())
+                    .map(Company::getName)
+                    .orElse("기타");
+        }
+
+        // 2. Document 변환
+        NewsDocument document = NewsDocument.builder()
+                .id(dto.getId())
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .publisher(dto.getPublisher())
+                .publishedAt(dto.getPublishedAt())
+                .companyCode(dto.getCompanyId())
+                .companyName(companyName) // 조회한 이름 매핑
+                .build();
+
+        // 3. ES 저장
+        newsSearchRepository.save(document);
     }
 }


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 뉴스] 뉴스 데이터 정합성 보장을 위한 Outbox Pattern 적용 및 검색 동기화 구현

---

## 🔀 PR 개요
- 뉴스 데이터 저장 시 MySQL과 Elasticsearch 간의 트랜잭션 불일치(Double Write) 문제를 해결하기 위해 Transactional Outbox Pattern을 도입하고, 비동기 스케줄러를 통해 데이터 정합성을 확보했습니다.

---

## ✅ 작업 내용
- 1. Outbox Pattern 도입
OutboxEvent 엔티티 추가: 이벤트 상태(PENDING, PUBLISHED)와 Payload(JSON)를 저장할 테이블 설계.

NewsService 리팩토링: 기존의 Elasticsearch 직접 저장 로직을 제거하고, 뉴스 저장 시 Outbox 이벤트 발행을 동일 트랜잭션으로 묶어 원자성 보장.

- 2. 비동기 인덱싱 스케줄러 구현
OutboxEventScheduler: 2초마다 PENDING 상태의 이벤트를 감지하여 처리.

NewsEsDto 구현: Elasticsearch 인덱싱을 위한 전용 DTO 생성 (Jackson 직렬화/역직렬화 지원 및 기업 정보 매핑 필드 추가).

NewsSearchService: 스케줄러가 호출할 ES 저장 로직 구현 (companyId를 통해 기업명 매핑 후 저장).

- 3. 기타 설정 및 마이그레이션
Dockerfile 수정: 팀 표준에 맞춰 Base Image를 Java 17로 변경 및 타임존(Asia/Seoul) 설정 추가.

Backfill API: 기존 뉴스 데이터에 대해 Outbox 이벤트를 생성하는 마이그레이션 로직 추가(검증 완료).

---

## 📌 관련 이슈
- Close #31

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
