### PR TITLE
Refactor: 뉴스 검색 데이터 구조 개선 및 중복 제거, Jenkins 설정 수정

### DIFF
--- a/src/main/java/com/example/noru/company/document/CompanyDocument.java
+++ b/src/main/java/com/example/noru/company/document/CompanyDocument.java
@@ -20,7 +20,7 @@ public class CompanyDocument {
     private Long id;
 
     @Field(type = FieldType.Keyword)
-    private String stockCode;
+    private String companyId;
 
     @Field(type = FieldType.Text, analyzer = "nori")
     private String name;

--- a/src/main/java/com/example/noru/company/rds/repository/CompanySearchRepository.java
+++ b/src/main/java/com/example/noru/company/rds/repository/CompanySearchRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 public interface CompanySearchRepository extends ElasticsearchRepository<CompanyDocument, Long> {
 
     // 기업명(name)이나 종목코드(stockCode)에 키워드가 포함되면 검색
-    @Query("{\"multi_match\": {\"query\": \"?0\", \"fields\": [\"name\", \"stockCode\"]}}")
+    @Query("{\"multi_match\": {\"query\": \"?0\", \"fields\": [\"name\", \"companyId\"]}}")
     List<CompanyDocument> searchByNameOrCode(String keyword);
 }

--- a/src/main/java/com/example/noru/news/document/NewsDocument.java
+++ b/src/main/java/com/example/noru/news/document/NewsDocument.java
@@ -5,10 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.elasticsearch.annotations.DateFormat;
-import org.springframework.data.elasticsearch.annotations.Document;
-import org.springframework.data.elasticsearch.annotations.Field;
-import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.*;
 
 import java.time.LocalDateTime;
 
@@ -22,7 +19,12 @@ public class NewsDocument {
     @Id
     private Long id;
 
-    @Field(type = FieldType.Text, analyzer = "nori")
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, analyzer = "nori"),
+            otherFields = {
+                    @InnerField(suffix = "keyword", type = FieldType.Keyword)
+            }
+    )
     private String title;
 
     @Field(type = FieldType.Text, analyzer = "nori")
@@ -42,4 +44,7 @@ public class NewsDocument {
 
     @Field(type = FieldType.Text)
     private String url;
+
+    @Field(type = FieldType.Text)
+    private String thumbnailUrl;
 }

--- a/src/main/java/com/example/noru/news/rds/dto/NewsEsDto.java
+++ b/src/main/java/com/example/noru/news/rds/dto/NewsEsDto.java
@@ -22,6 +22,8 @@ public class NewsEsDto {
     // [중요] 기업 매핑을 위해 반드시 필요!
     private String companyId;
 
+    private String thumbnailUrl;
+
     // News 엔티티를 받아서 DTO로 변환하는 정적 메서드
     public static NewsEsDto from(News news) {
         return NewsEsDto.builder()
@@ -31,7 +33,8 @@ public class NewsEsDto {
                 .content(news.getContent())
                 .publishedAt(news.getPublishedAt()) // 시간 정보까지 그대로 전달
                 .publisher(news.getPublisher())
-                .companyId(news.getCompanyId())     // 필드 매핑 추가
+                .companyId(news.getCompanyId())
+                .thumbnailUrl(news.getThumbnailUrl())
                 .build();
     }
 }

--- a/src/main/java/com/example/noru/news/rds/service/NewsSearchService.java
+++ b/src/main/java/com/example/noru/news/rds/service/NewsSearchService.java
@@ -70,7 +70,8 @@ public class NewsSearchService {
                 .publisher(dto.getPublisher())
                 .publishedAt(dto.getPublishedAt())
                 .companyCode(dto.getCompanyId())
-                .companyName(companyName) // 조회한 이름 매핑
+                .companyName(companyName)
+                .thumbnailUrl(dto.getThumbnailUrl())
                 .build();
 
         // 3. ES 저장

--- a/src/main/java/com/example/noru/news/rds/service/NewsSyncService.java
+++ b/src/main/java/com/example/noru/news/rds/service/NewsSyncService.java
@@ -60,7 +60,8 @@ public class NewsSyncService {
                             .publisher(news.getPublisher())
                             .publishedAt(news.getPublishedAt())
                             .companyCode(String.valueOf(news.getCompanyId())) // 필요하다면 stockCode로 변경 가능
-                            .companyName(companyName) // 👈 여기에 찾은 이름을 쏙 넣습니다!
+                            .companyName(companyName)
+                            .thumbnailUrl(news.getThumbnailUrl())
                             .build();
                 })
                 .collect(Collectors.toList());
@@ -81,7 +82,7 @@ public class NewsSyncService {
         List<CompanyDocument> docs = allCompanies.stream()
                 .map(c -> CompanyDocument.builder()
                         .id(c.getId())
-                        .stockCode(c.getStockCode())
+                        .companyId(c.getStockCode())
                         .name(c.getName())
                         .isDomestic(c.isDomestic())
                         .isListed(c.isListed())

--- a/src/main/java/com/example/noru/news/repository/NewsSearchRepository.java
+++ b/src/main/java/com/example/noru/news/repository/NewsSearchRepository.java
@@ -16,6 +16,22 @@ public interface NewsSearchRepository extends ElasticsearchRepository<NewsDocume
     // 회사 코드로 검색
     List<NewsDocument> findByCompanyCode(String companyCode);
 
-    @Query("{\"multi_match\": {\"query\": \"?0\", \"fields\": [\"title\", \"content\", \"companyName\"]}}")
+    @Query("""
+        {
+          "bool": {
+            "must": [
+              {
+                "multi_match": {
+                  "query": "?0",
+                  "fields": ["title^3", "content", "companyName"]
+                }
+              }
+            ]
+          },
+          "collapse": {
+            "field": "title.keyword"
+          }
+        }
+    """)
     List<NewsDocument> searchByKeyword(String keyword);
 }


### PR DESCRIPTION
## ✅ PR 제목
- [리팩토링/버그] 뉴스 검색 데이터 구조 개선(중복 제거/필드 변경) 및 배포 스크립트 수정

---

## 🔀 PR 개요
- 프론트엔드 연동을 위해 검색 결과 필드(`companyId`, `thumbnail`)를 최신화하고, 검색 시 중복된 뉴스가 노출되는 문제를 해결했으며 Jenkins 배포 스크립트의 오타를 수정했습니다.

---

## ✅ 작업 내용
### 1. Elasticsearch 데이터 구조 개선
- **`CompanyDocument`**: `stockCode` 필드명을 `companyId`로 변경하여 명칭 통일.
- **`NewsDocument`**: 
  - 검색 목록에 썸네일을 표시하기 위해 `thumbnailUrl` 필드 추가.
  - 중복 제거(Collapse)를 위해 `title` 필드에 `@MultiField`(keyword) 설정 적용.

### 2. 검색 로직 개선 (중복 제거)
- **`NewsSearchRepository`**: Elasticsearch의 `collapse` 기능을 쿼리에 적용하여, 동일한 제목의 뉴스는 검색 결과에서 1건만 노출되도록 수정.

### 3. 인프라 설정 수정
- **`Jenkinsfile`**: Docker 실행 시 주입되는 Neo4j 연결 주소 오타 수정 (`10.0..3.151` → `10.0.3.151`).

---

## 📌 관련 이슈
- Close #41 

---

## 📸 스크린샷 (선택)
- (선택사항: 중복 제거된 깔끔한 검색 결과 JSON 캡처가 있다면 첨부)

---

## ⚠️ 기타 사항
- **[필독] Elasticsearch 인덱스 재생성 필요**
  - Document 구조(`Mapping`)가 변경되었으므로, 배포 후 반드시 **기존 인덱스를 삭제하고 재동기화 API를 호출**해야 합니다.
  1. `DELETE /news_index`, `DELETE /company_index`
  2. `POST /api/admin/sync/companies`
  3. `POST /api/admin/sync/news`