### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/example/noru/news/controller/NewsSearchController.java
+++ b/src/main/java/com/example/noru/news/controller/NewsSearchController.java
@@ -6,6 +6,7 @@ import com.example.noru.news.document.NewsDocument;
 import com.example.noru.news.rds.dto.SearchResponseDto;
 import com.example.noru.news.rds.service.NewsSearchService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/example/noru/news/repository/NewsSearchRepository.java
+++ b/src/main/java/com/example/noru/news/repository/NewsSearchRepository.java
@@ -16,22 +16,22 @@ public interface NewsSearchRepository extends ElasticsearchRepository<NewsDocume
     // 회사 코드로 검색
     List<NewsDocument> findByCompanyCode(String companyCode);
 
-    @Query("""
-        {
-          "bool": {
-            "must": [
-              {
-                "multi_match": {
-                  "query": "?0",
-                  "fields": ["title^3", "content", "companyName"]
-                }
-              }
-            ]
-          },
-          "collapse": {
-            "field": "title.keyword"
-          }
-        }
-    """)
-    List<NewsDocument> searchByKeyword(String keyword);
+//    @Query("""
+//        {
+//          "bool": {
+//            "must": [
+//              {
+//                "multi_match": {
+//                  "query": "?0",
+//                  "fields": ["title^3", "content", "companyName"]
+//                }
+//              }
+//            ]
+//          },
+//          "collapse": {
+//            "field": "title.keyword"
+//          }
+//        }
+//    """)
+//    List<NewsDocument> searchByKeyword(String keyword);
 }


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 검색] 검색 로직 NativeQuery로 변경 및 배포 환경 안정화 (스케줄러/프론트)

---

## 🔀 PR 개요
- Elasticsearch 검색 시 중복 제거(Collapse) 쿼리 문법 오류를 해결하기 위해 Service 레이어의 로직을 리팩토링하고, 스케줄러 및 프론트엔드의 배포 실패/종료 문제를 수정했습니다.

---

## ✅ 작업 내용
### 1. 백엔드 (검색 로직)
- **`NewsSearchService` 리팩토링**: 
  - 기존 Repository의 `@Query` 어노테이션 방식은 `collapse` 필드를 `query` 내부로 잘못 감싸는 문제가 있었습니다.
  - 이를 해결하기 위해 `ElasticsearchOperations`와 `NativeQuery`를 사용하여 쿼리를 직접 빌드하는 방식으로 변경했습니다.
- **`NewsSearchRepository`**: 불필요해진 `searchByKeyword` 메서드 삭제.

### 2. 스케줄러 (Scheduler)
- **`build.gradle` 수정**: `spring-boot-starter-web` 의존성을 추가하여, 컨테이너 실행 시 웹 서버(Tomcat)가 구동되도록 변경했습니다. (실행 직후 프로세스 종료 방지)

### 3. 프론트엔드 (Frontend)
- **`Dockerfile` & `next.config.ts` 수정**: 
  - App Server(폐쇄망)에서 외부 패키지 다운로드가 불가능한 점을 고려하여, `output: 'standalone'` 설정을 적용했습니다.
  - 런타임(`runner`) 단계에서 `npm install`을 제거하고 빌드 산출물만 실행하도록 변경했습니다.

---

## 📌 관련 이슈
- Close #(이슈번호)

---

## 📸 스크린샷 (선택)
- **Postman 테스트 결과 (200 OK, 정상 응답)**
  *(여기에 아까 확인하신 Postman 결과 캡처를 넣으시면 좋습니다)*

---

## ⚠️ 기타 사항
- **[확인]** 배포 후 `curl` 또는 Postman으로 `/api/v1/search/total` 호출 시 400 에러 없이 데이터가 잘 내려오는지 확인 부탁드립니다.