### PR TITLE
[BE | 현재가] 해외 현재가 조회

### DIFF
--- a/src/main/java/com/example/noru/company/rds/entity/Company.java
+++ b/src/main/java/com/example/noru/company/rds/entity/Company.java
@@ -26,4 +26,6 @@ public class Company {
     private boolean isDomestic;
 
     private boolean isListed;
+
+    private String exchange;
 }

--- a/src/main/java/com/example/noru/company/rds/repository/CompanyRepository.java
+++ b/src/main/java/com/example/noru/company/rds/repository/CompanyRepository.java
@@ -19,4 +19,6 @@ public interface CompanyRepository extends JpaRepository<Company, String> {
     List<Company> findAllByStockCode(String stockCode);
 
     Optional<Company> findByStockCode(String companyId);
+
+    List<Company> findByIsDomesticFalseAndIsListedTrueAndExchangeIsNotNull();
 }

--- a/src/main/java/com/example/noru/company/rds/service/CompanyService.java
+++ b/src/main/java/com/example/noru/company/rds/service/CompanyService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +36,10 @@ public class CompanyService {
 
     public List<String> getDomesticListedCompanies() {
         return companyRepository.findValidCompanyIds();
+    }
+
+    public List<Company> getOverseasListedCompanies() {
+        return companyRepository.findByIsDomesticFalseAndIsListedTrueAndExchangeIsNotNull();
     }
 
     @Transactional
@@ -101,4 +106,5 @@ public class CompanyService {
 
         return new WordCloudDto(companyId, wordList);
     }
+
 }

--- a/src/main/java/com/example/noru/news/rds/service/NewsService.java
+++ b/src/main/java/com/example/noru/news/rds/service/NewsService.java
@@ -189,9 +189,11 @@ public class NewsService {
                             }
 
                             String stockCode = company.getStockCode();
+                            String exchange = company.getExchange(); // null 이면 국내
 
                             PriceDto priceDto = new PriceDto(stockCode, -1, 0, 0.0);
-                            String json = priceRedisService.get(stockCode);
+
+                            String json = priceRedisService.get(exchange, stockCode);
                             if (json != null) {
                                 priceDto = PriceParsingConfig.parsePrice(stockCode, json);
                             }

--- a/src/main/java/com/example/noru/price/service/OverseasPriceFetchService.java
+++ b/src/main/java/com/example/noru/price/service/OverseasPriceFetchService.java
@@ -25,15 +25,16 @@ public class OverseasPriceFetchService {
         log.info("🌍 Overseas price fetch [{}:{}]", exchange, stockCode);
 
         return restClient.get()
-                .uri(baseUrl + "/uapi/overseas-stock/v1/quotations/price",
+                .uri(baseUrl + "/uapi/overseas-price/v1/quotations/price-detail",
                         uri -> uri
+                                .queryParam("AUTH")
                                 .queryParam("EXCD", exchange)
                                 .queryParam("SYMB", stockCode)
                                 .build())
                 .header("authorization", "Bearer " + token)
                 .header("appkey", appKey)
                 .header("appsecret", appSecret)
-                .header("tr_id", "HHDFS00000300")
+                .header("tr_id", "HHDFS76200200")
                 .retrieve()
                 .body(String.class);
     }

--- a/src/main/java/com/example/noru/price/service/OverseasPriceFetchService.java
+++ b/src/main/java/com/example/noru/price/service/OverseasPriceFetchService.java
@@ -1,0 +1,40 @@
+package com.example.noru.price.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OverseasPriceFetchService {
+
+    private final RestClient restClient;
+
+    @Value("${app.korea-invest.base-url}")
+    private String baseUrl;
+    @Value("${app.korea-invest.appkey}")
+    private String appKey;
+    @Value("${app.korea-invest.appsecret}")
+    private String appSecret;
+
+    public String fetch(String token, String exchange, String stockCode) {
+
+        log.info("🌍 Overseas price fetch [{}:{}]", exchange, stockCode);
+
+        return restClient.get()
+                .uri(baseUrl + "/uapi/overseas-stock/v1/quotations/price",
+                        uri -> uri
+                                .queryParam("EXCD", exchange)
+                                .queryParam("SYMB", stockCode)
+                                .build())
+                .header("authorization", "Bearer " + token)
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "HHDFS00000300")
+                .retrieve()
+                .body(String.class);
+    }
+}

--- a/src/main/java/com/example/noru/price/service/PriceRedisService.java
+++ b/src/main/java/com/example/noru/price/service/PriceRedisService.java
@@ -14,7 +14,7 @@ public class PriceRedisService {
     private static final String PREFIX = "price:";
 
     // TTL 정책
-    private static final long DOMESTIC_TTL_SEC = 10;
+    private static final long DOMESTIC_TTL_SEC = 60;
     private static final long OVERSEAS_TTL_SEC = 60 * 60 * 24; // 24h
 
     /* =========================

--- a/src/main/java/com/example/noru/price/service/PriceRedisService.java
+++ b/src/main/java/com/example/noru/price/service/PriceRedisService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.concurrent.TimeUnit;
+
 @Service
 @RequiredArgsConstructor
 public class PriceRedisService {
@@ -11,20 +13,37 @@ public class PriceRedisService {
     private final StringRedisTemplate redis;
     private static final String PREFIX = "price:";
 
+    // TTL 정책
+    private static final long DOMESTIC_TTL_SEC = 10;
+    private static final long OVERSEAS_TTL_SEC = 60 * 60 * 24; // 24h
+
+    /* =========================
+     * 🇰🇷 국내
+     * ========================= */
     public void saveDomestic(String stockCode, String json) {
         redis.opsForValue().set(
                 PREFIX + "DOMESTIC:" + stockCode,
-                json
+                json,
+                DOMESTIC_TTL_SEC,
+                TimeUnit.SECONDS
         );
     }
 
+    /* =========================
+     * 🌍 해외
+     * ========================= */
     public void saveOverseas(String exchange, String stockCode, String json) {
         redis.opsForValue().set(
                 PREFIX + exchange + ":" + stockCode,
-                json
+                json,
+                OVERSEAS_TTL_SEC,
+                TimeUnit.SECONDS
         );
     }
 
+    /* =========================
+     * 공통 조회
+     * ========================= */
     public String get(String exchange, String stockCode) {
         if (exchange == null) {
             return redis.opsForValue()

--- a/src/main/java/com/example/noru/price/service/PriceRedisService.java
+++ b/src/main/java/com/example/noru/price/service/PriceRedisService.java
@@ -4,21 +4,33 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class PriceRedisService {
 
-    private final StringRedisTemplate stringRedisTemplate;
-
+    private final StringRedisTemplate redis;
     private static final String PREFIX = "price:";
 
-
-    public void savePrice(String companyId, String price) {
-        stringRedisTemplate.opsForValue().set(PREFIX + companyId, price);
+    public void saveDomestic(String stockCode, String json) {
+        redis.opsForValue().set(
+                PREFIX + "DOMESTIC:" + stockCode,
+                json
+        );
     }
 
-    public String get(String companyId) {
-        return stringRedisTemplate.opsForValue().get(PREFIX + companyId);
+    public void saveOverseas(String exchange, String stockCode, String json) {
+        redis.opsForValue().set(
+                PREFIX + exchange + ":" + stockCode,
+                json
+        );
+    }
+
+    public String get(String exchange, String stockCode) {
+        if (exchange == null) {
+            return redis.opsForValue()
+                    .get(PREFIX + "DOMESTIC:" + stockCode);
+        }
+        return redis.opsForValue()
+                .get(PREFIX + exchange + ":" + stockCode);
     }
 }
-


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 현재가] 해외 현재가 조회

---

## 🔀 PR 개요
- 국내·해외 주식 가격 조회 로직을 분리하고, 국내 가격 조회를 병렬 처리로 개선하여 성능을 최적화했습니다.

---

## ✅ 작업 내용
- 국내 주식 가격 조회
  - REST 기반 가격 조회 유지
  - ExecutorService를 활용한 병렬 처리 적용 (Thread Pool 8)
  -  RateLimiter(3.3 req/sec) 유지로 API 호출 제한 준수
  - Redis 캐시 TTL을 1분으로 설정하여 실시간성 확보
- 해외 주식 가격 조회
  - 국내 로직과 분리된 OverseasPriceFetchService 도입
  - 해외 가격은 하루 1회 스케줄링으로 호출 빈도 최적화
  - Redis TTL을 24시간으로 설정
  - Redis 캐시 구조 개선
- 국내: price:DOMESTIC:{stockCode}
- 해외: price:{exchange}:{stockCode}
  - 국내/해외 구분 없이 공통 조회 가능하도록 PriceRedisService 정리
  - 가격 파싱 로직 개선
  - 국내/해외 API 응답 JSON 구조 차이를 PriceParsingConfig에서 통합 처리
  - 해외 가격 데이터에서 현재가(t_xprc), 전일대비(t_xdif), 등락률(t_xrat)만 사용
- 아키텍처 개선
  - 가격 조회 로직을 Scheduler/Service/Controller 단으로 명확히 분리

---

## 📌 관련 이슈
- Close #38

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
