### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/example/noru/company/rds/service/CompanySearchService.java
+++ b/src/main/java/com/example/noru/company/rds/service/CompanySearchService.java
@@ -1,0 +1,38 @@
+package com.example.noru.company.rds.service;
+
+import com.example.noru.company.document.CompanyDocument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CompanySearchService {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    public List<CompanyDocument> searchByNameOrCode(String keyword) {
+        Query query = NativeQuery.builder()
+                .withQuery(q -> q
+                        .multiMatch(m -> m
+                                .fields("name", "companyId")
+                                .query(keyword)
+                        )
+                )
+                .build();
+
+        SearchHits<CompanyDocument> searchHits = elasticsearchOperations.search(query, CompanyDocument.class);
+
+        return searchHits.stream()
+                .map(hit -> hit.getContent())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/noru/news/controller/NewsSearchController.java
+++ b/src/main/java/com/example/noru/news/controller/NewsSearchController.java
@@ -2,6 +2,7 @@ package com.example.noru.news.controller;
 
 import com.example.noru.company.document.CompanyDocument;
 import com.example.noru.company.rds.repository.CompanySearchRepository;
+import com.example.noru.company.rds.service.CompanySearchService;
 import com.example.noru.news.document.NewsDocument;
 import com.example.noru.news.rds.dto.SearchResponseDto;
 import com.example.noru.news.rds.service.NewsSearchService;
@@ -19,7 +20,7 @@ import java.util.List;
 public class NewsSearchController {
 
     private final NewsSearchService newsSearchService;
-    private final CompanySearchRepository companySearchRepository;
+    private final CompanySearchService companySearchService;
 
     // 1. [통합 검색] 뉴스(제목+내용+기업명) + 기업(이름+코드) 동시에 검색
     // 사용법: GET /api/news/total?keyword=삼성
@@ -30,7 +31,7 @@ public class NewsSearchController {
         List<NewsDocument> newsResult = newsSearchService.searchGlobal(keyword);
 
         // 1-2. 기업 검색 (기업명 + 종목코드)
-        List<CompanyDocument> companyResult = companySearchRepository.searchByNameOrCode(keyword);
+        List<CompanyDocument> companyResult = companySearchService.searchByNameOrCode(keyword);
 
         // 1-3. 결과 묶어서 반환
         SearchResponseDto response = SearchResponseDto.builder()


### PR DESCRIPTION
## ✅ PR 제목
- [BE | 검색] 검색 로직 NativeQuery 리팩토링 및 스케줄러/프론트 배포 환경 개선

---

## 🔀 PR 개요
- Elasticsearch 검색 쿼리 문법 오류(400)를 해결하기 위해 Repository 방식에서 `NativeQuery` 방식으로 리팩토링하고, 스케줄러 및 프론트엔드의 배포 실패 원인을 수정했습니다.

---

## ✅ 작업 내용
### 1. 검색 로직 리팩토링 (Backend)
- **`NewsSearchService` & `CompanySearchService`**:
  - 기존 Repository 인터페이스의 `@Query` 방식이 복잡한 JSON 쿼리(Collapse 등)를 제대로 처리하지 못해 400 에러가 발생했습니다.
  - 이를 해결하기 위해 `ElasticsearchOperations`와 `NativeQuery` 빌더를 사용하여 안전하게 쿼리를 생성하도록 변경했습니다.
- **`NewsSearchController`**: Repository 대신 새로 만든 Service를 주입받도록 수정했습니다.

### 2. 인프라 및 빌드 설정 (DevOps)
- **스케줄러 (Scheduler)**: `spring-boot-starter-web` 의존성을 추가하여 컨테이너가 실행 후 바로 종료되지 않도록 수정했습니다.
- **프론트엔드 (Frontend)**: `next.config.ts`에 `output: 'standalone'`을 추가하고, Dockerfile을 수정하여 인터넷이 없는 폐쇄망 환경에서도 실행되도록 개선했습니다.

---

## 📌 관련 이슈
- Close #(이슈번호)

---

## 📸 스크린샷 (선택)
- **Postman 테스트 결과**: `/api/v1/search/total` 호출 시 뉴스 및 기업 데이터 정상 응답 (200 OK)

---

## ⚠️ 기타 사항
- **[중요]** Elasticsearch 인덱스 설정(`nori` analyzer)이 변경되었으므로, 배포 후 **인덱스 삭제 및 데이터 재동기화**가 필요합니다.
  1. `DELETE /company_index`
  2. `PUT /company_index` (설정 주입)
  3. `POST /api/news/sync/companies/full`